### PR TITLE
Add a run.sh script to install dependencies and download the AQR dataset automatically

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+/Mkt.csv
+/SMB.csv
+/HML.csv
+/QMJ.csv
+/UMD.csv
+/RF.csv
+/Test_XIC_USD_returns3.csv
+/__pycache__/
+/venv/

--- a/README.txt
+++ b/README.txt
@@ -14,7 +14,7 @@ Prior to running the scripts, the following lines of code must be executed if th
 
 pip install pandas
 pip install numpy
-pip install DateTime
+pip install xlrd
 pip install statsmodels
 pip install urllib3
 pip install zipfile37
@@ -25,11 +25,3 @@ Prior to running the CDN_listed_CDN_Equity.py script for the first time, run get
 Once the dataset is downloaded, the getAQR_QMJ.py script is not required to be executed unless updated data is required. 
 
 CDN_Factor_Regression.py contains the functions CDN_Listed_CDN_Equity, CDN_Listed_US_Equity, and US_Listed_US_Equity if the user prefers to have everything together in one file.
-
-
-
-
-
-
-
-

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,27 @@
+#!/bin/sh -e
+
+cd "`dirname $0`"
+MODULES="pandas numpy statsmodels zipfile37 investpy yfinance xlrd"
+VENV_PATH="$PWD/venv"
+SENTINEL_PATH="$VENV_PATH/.setupdone"
+
+if [ -f "$SENTINEL_PATH" ] && [[ $(< "$SENTINEL_PATH") == "$MODULES" ]]
+then
+  . "$VENV_PATH/bin/activate"
+else
+  echo "Creating virtual environment"
+  rm -rf "$VENV_PATH"
+  python3 -m venv "$VENV_PATH"
+  . "$VENV_PATH/bin/activate"
+  pip3 install --upgrade pip
+  pip3 install $MODULES
+  echo "$MODULES" > "$SENTINEL_PATH"
+fi
+
+if [ ! -f "Mkt.csv" ]
+then
+  echo "Downloading AQR data files"
+  python3 getAQR_QMJ.py
+fi
+
+python3 CDN_listed_CDN_Equity.py


### PR DESCRIPTION
I wanted to run your scripts, but didn't want to install all the packages on my system. What this script does is:

* create a python virtual environment
* install all the packages
* download the data files
* run the script

It skips the steps that are no longer needed in subsequent runs. I guess you are using Windows and the script would not work for that. I tested it on my Mac.

I also spotted the missing `xlrd` required module (datetime is always included in your python distribution so I removed that), and added a `.gitignore` file with all the generated files to avoid committing them accidentally.